### PR TITLE
emit event on load

### DIFF
--- a/src/a-painter-loader.js
+++ b/src/a-painter-loader.js
@@ -118,6 +118,7 @@ AFRAME.registerComponent('a-painter-loader', {
 
   loadFromUrl: function (url, binary) {
     var self = this;
+    var el = this.el;
     var loader = new THREE.FileLoader(this.manager);
     loader.crossOrigin = 'anonymous';
     if (binary === true) { loader.setResponseType('arraybuffer'); }
@@ -128,6 +129,7 @@ AFRAME.registerComponent('a-painter-loader', {
       } else {
         self.loadJSON(JSON.parse(buffer));
       }
+      el.emit('model-loaded', {format: 'a-painter', model: null});
     });
   }
 


### PR DESCRIPTION
added an event similar to other model loaders, so we know when it's done.

There isn't a "model" to put in the event, so I just set that to null.  Perhaps want to use a different event name?  Seemed better to just use model-loaded, since it was used by the other loaders.